### PR TITLE
Reset the role group dropdown when a group is selected

### DIFF
--- a/commands/self-roles/self-roles.js
+++ b/commands/self-roles/self-roles.js
@@ -47,6 +47,8 @@ exports.select = async (client, interaction, args) => {
   const hasRequirementsMet = hasRequirements && !group.requirements.some((requirement) => roles.includes(requirement))
 
   if (action == "menu") {
+    await interaction.update({});
+
     const multiple = group.multiple;
     const row = new ActionRowBuilder().addComponents(
       new StringSelectMenuBuilder()
@@ -108,7 +110,7 @@ exports.select = async (client, interaction, args) => {
         text: group.embed_footer,
       });
 
-    interaction.reply({
+    interaction.followUp({
       content: `Add/Remove a role from the menu below!`,
       embeds: [imageEmbed, groupEmbed],
       components: [row, row2],


### PR DESCRIPTION
- currently, when the user selects a role group from the premium role selector, the dropdown does not reset, preventing the user from selecting that group again if they dismiss the embed, only allowing them to select the other option or reload their client
- this will submit an empty update to the embed, which will not show the `(edited)` indicator and will cause the user's selection in the dropdown to reset, which will allow them to select the same option again